### PR TITLE
Driver API: Implement database driver actions and resource status

### DIFF
--- a/pkg/apis/db/v1alpha1/database_types.go
+++ b/pkg/apis/db/v1alpha1/database_types.go
@@ -71,12 +71,13 @@ type AwsCredentials struct {
 
 // DatabaseSpec defines the desired state of Database
 type DatabaseSpec struct {
-	Provider       string            `json:"provider"`
-	Name           string            `json:"name"`
-	Connect        map[string]string `json:"connect"`
-	Credentials    Credentials       `json:"credentials"`
-	BackupTo       BackupTo          `json:"backupTo,omitempty"`
-	AwsCredentials AwsCredentials    `json:"awsCredentials,omitempty"`
+	Provider          string            `json:"provider"`
+	Name              string            `json:"name"`
+	Connect           map[string]string `json:"connect"`
+	MasterCredentials Credentials       `json:"masterCredentials"`
+	UserCredentials   Credentials       `json:"userCredentials"`
+	BackupTo          BackupTo          `json:"backupTo,omitempty"`
+	AwsCredentials    AwsCredentials    `json:"awsCredentials,omitempty"`
 }
 
 // DatabaseStatus defines the observed state of Database

--- a/pkg/apis/db/v1alpha1/database_types.go
+++ b/pkg/apis/db/v1alpha1/database_types.go
@@ -34,14 +34,14 @@ type AwsSecretRef struct {
 
 // ValueFrom supports retrieving a credential from elsewhere
 type ValueFrom struct {
-	SecretKeyRef    SecretKeyRef `json:"secretKeyRef"`
-	AwsSecretKeyRef AwsSecretRef `json:"awsSecretKeyRef"`
+	SecretKeyRef    SecretKeyRef `json:"secretKeyRef,omitempty"`
+	AwsSecretKeyRef AwsSecretRef `json:"awsSecretKeyRef,omitempty"`
 }
 
 // Credential supports either a literal value, or retrieving from elsewhere
 type Credential struct {
-	Value     string    `json:"value"`
-	ValueFrom ValueFrom `json:"valueFrom"`
+	Value     string    `json:"value,omitempty"`
+	ValueFrom ValueFrom `json:"valueFrom,omitempty"`
 }
 
 // Credentials are literal credentials provided in the database resource

--- a/pkg/apis/db/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/db/v1alpha1/zz_generated.deepcopy.go
@@ -272,7 +272,8 @@ func (in *DatabaseSpec) DeepCopyInto(out *DatabaseSpec) {
 			(*out)[key] = val
 		}
 	}
-	out.Credentials = in.Credentials
+	out.MasterCredentials = in.MasterCredentials
+	out.UserCredentials = in.UserCredentials
 	out.BackupTo = in.BackupTo
 	out.AwsCredentials = in.AwsCredentials
 	return

--- a/pkg/driver/api.go
+++ b/pkg/driver/api.go
@@ -16,7 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 )
 
 type Container struct {
@@ -47,7 +49,7 @@ type Driver struct {
 	Backup   func(*Driver, *io.Writer) error
 }
 
-var log = logf.Log.WithName("provider-api")
+var log logr.Logger
 
 // RegisterDriver registers your driver with the provider
 func (p *Container) RegisterDriver(d *Driver) error {
@@ -211,6 +213,12 @@ func (p *Container) reconcileBackup() error {
 // Run the provider, which will reconcile the provided database/backup
 // using the registered drivers
 func (p *Container) Run() error {
+	zlog, err := zap.NewDevelopment()
+	if err != nil {
+		panic(err)
+	}
+	log = zapr.NewLogger(zlog).WithName("db-operator")
+
 	if err := p.setup(); err != nil {
 		return err
 	}

--- a/pkg/driver/api.go
+++ b/pkg/driver/api.go
@@ -142,7 +142,7 @@ func (p *Container) readFromAwsSecret(s dbv1alpha1.AwsSecretRef) (string, error)
 
 func (p *Container) getCredential(cred dbv1alpha1.Credential) (string, error) {
 	if cred.Value != "" {
-		return "", nil
+		return cred.Value, nil
 	}
 	if cred.ValueFrom.SecretKeyRef.Name != "" {
 		return p.readFromKubernetesSecret(cred.ValueFrom.SecretKeyRef)


### PR DESCRIPTION
The main goal here is to make it so right driver functions are called, and that the status on the database resource is updated correctly.

Some other things along the way:
- Fixed a bit of credentials retrieval, though the AWS and k8s secrets are still todo.
- Altered the credentials in the database resource so it can contain both creds for the master and the user.
- Reworked logging so logs from `pkg/driver/api.go` appear in stdout.
- Tried (and I think failed) to make it so when we update the database resource's status, it doesn't set `(Master|User)Credentials.(password|username).valueFrom` even though I wasn't using it and all values were empty. I think this means I need to poke the json marshalling a bit more and understand optional fields.